### PR TITLE
delete obsolute frameborder attribute from the the iframe tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         <div class="container">
             <section class="videoplayer">
 
-                <iframe width="784" height="441" src="https://www.youtube.com/embed/B3MDJsggfDg" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                <iframe width="784" height="441" src="https://www.youtube.com/embed/B3MDJsggfDg"  allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
             </section>
 
             <article class="bottomOfVideoplayer">


### PR DESCRIPTION
Deleted the borderframe attribute from the iframe tag for it is no longer in use.